### PR TITLE
Reduce the size of the published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
   "bin": {
     "showdown": "bin/showdown.js"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
   "devDependencies": {
     "chai": "4.1.x",
     "grunt": "^1.0.3",


### PR DESCRIPTION
This PR simply adds a _files_ field to the _package.json_ so that the size of the published package is reduced by only including the files required (the _bin_ and the _dist_ folders).

Before: https://packagephobia.now.sh/result?p=showdown _(All files from this repository included)_

After:
```sh
$ npm publish --dry
npm notice
npm notice package: showdown@2.0.0-alpha1
npm notice === Tarball Contents ===
npm notice 1.6kB   package.json
npm notice 37.4kB  CHANGELOG.md
npm notice 1.1kB   LICENSE
npm notice 18.8kB  README.md
npm notice 47B     bin/showdown.js
npm notice 173.5kB dist/showdown.js
npm notice 489.0kB dist/showdown.js.map
npm notice 81.1kB  dist/showdown.min.js
npm notice 91.9kB  dist/showdown.min.js.map
npm notice === Tarball Details ===
npm notice name:          showdown
npm notice version:       2.0.0-alpha1
npm notice package size:  183.2 kB
npm notice unpacked size: 894.4 kB
npm notice shasum:        7fa92ad99d8c6962a6eeabe68700a99c454204e4
npm notice integrity:     sha512-pgMk7pliEMzaR[...]Q9wgfrcCdnijg==
npm notice total files:   9
npm notice
+ showdown@2.0.0-alpha1
```